### PR TITLE
Devel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,6 @@ LazyData: true
 URL: https://github.com/fisabio/medear
 BugReports: https://github.com/fisabio/medear/issues
 Imports:
-    caRtociudad (>= 0.5.5),
     data.table (>= 1.11.4),
     sp (>= 1.3-1),
     httr (>= 1.3.1),
@@ -32,7 +31,6 @@ Imports:
     sodium (>= 1.1),
     utils (>= 3.3.0),
     stats (>= 3.3.0)
-Remotes: carlosvergara/caRtociudad
 RoxygenNote: 6.0.1
 ByteCompile: yes
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: medear
 Title: Poblaciones y cartografia por seccion censal INE
-Version: 0.4.3
-Date: 2018-10-01
+Version: 0.4.4
+Date: 2018-10-03
 Authors@R: c(
     person("Grupo MEDEA 3",  role = "aut"),
     person("Carlos", "Vergara-Hernandez", email = "vergara_car@gva.es", role = c("aut", "cre"))

--- a/R/descarga_datos.R
+++ b/R/descarga_datos.R
@@ -35,10 +35,16 @@
 #'   \item{CPRO}{Código de la provincia.} \item{CMUM}{Código del municipio.}
 #'   \item{DIST}{Código del distrito.} \item{SECC}{Código de la sección censal
 #'   reducido.} \item{CVIA}{Código de la vía reducido.} \item{EIN}{Primer portal
-#'   del tramo de vía.} \item{ESN}{Último portal del tramo de vía.}
+#'   del tramo de vía (incorpora decimales en caso de tener letra).}
+#'   \item{ESN}{Último portal del tramo de vía (incorpora decimales en caso de
+#'   tener letra).} \item{cod_upob}{Código de la entidad poblacional}
+#'   \item{ent_colectiva}{Nombre de la entidad colectiva.}
+#'   \item{ent_singular}{Nombre de la entidad singular.}
+#'   \item{diseminado}{Nombre del núcleo diseminado.}
 #'   \item{NVIAC}{Nombre de la vía.} \item{seccion}{Código de la sección censal
 #'   completo.} \item{year}{Año del tramero.} \item{via}{Código de la vía
-#'   completo.}
+#'   completo (el último dígito hace referencia a si el tramo de vía es sin
+#'   numeración, impar o par (0, 1, o 2, respectivamente).}
 #'
 #'   Cada fila representa un tramo de vía, puediendo repetirse la misma vía en
 #'   varias ocasiones en función de si su recorrido recae en varias secciones
@@ -77,9 +83,10 @@ descarga_trameros <- function(cod_provincia = c(paste0("0", 1:9), 10:52),
     mustWork = FALSE
   )
   estructura <- readr::fwf_positions(
-    start     = c(1, 3, 6, 8, 21, 43, 49, 54, 166),
-    end       = c(2, 5, 7, 10, 25, 47, 52, 57, 190),
-    col_names = c("CPRO", "CMUM", "DIST", "SECC", "CVIA", "CPOS", "EIN", "ESN", "NVIAC")
+    start     = c(1, 3, 6, 8, 21, 43, 48, 49, 53, 54, 58, 79, 86, 111, 136, 166),
+    end       = c(2, 5, 7, 10, 25, 47, 48, 52, 53, 57, 58, 85, 110, 135, 160, 190),
+    col_names = c("CPRO", "CMUM", "DIST", "SECC", "CVIA", "CPOS", "TINUM", "EIN", "letra1",
+                  "ESN", "letra2", "cod_upob", "ent_colectiva", "ent_singular", "diseminado", "NVIAC")
   )
   y_2001 <- FALSE
   if (2001 %in% years) {
@@ -155,20 +162,40 @@ descarga_trameros <- function(cod_provincia = c(paste0("0", 1:9), 10:52),
       if (!file.exists(ruta_tra[i, j])) {
         stop("No existe el archivo ", ruta_tra[i, j])
       }
-      tramero <- suppressWarnings(
-        readr::read_fwf(
-          file          = ruta_tra[i, j],
-          col_positions = estructura,
-          col_types     = readr::cols(.default = "c"),
-          progress      = FALSE,
-          locale        = readr::locale(encoding = "latin1")
+      tramero <-  as.data.table(
+        suppressWarnings(
+          readr::read_fwf(
+            file          = ruta_tra[i, j],
+            col_positions = estructura,
+            col_types     = readr::cols(.default = "c"),
+            progress      = FALSE,
+            locale        = readr::locale(encoding = "latin1")
+          )
         )
       )
-      trameros[[paste0("p", i, j)]] <- as.data.table(tramero)[, `:=`(
+      tramero[, `:=`(EIN = as.numeric(EIN), ESN = as.numeric(ESN))]
+      tramero$letra1 <- ifelse(
+        is.na(tramero$letra1) | (tramero$EIN == 0 & tramero$letra1 == "S"),
+        "",
+        tramero$letra1
+      )
+      tramero$letra2 <- ifelse(
+        is.na(tramero$letra2) | (tramero$EIN == 0 & tramero$letra2 == "S"),
+        "",
+        tramero$letra2
+      )
+      n_let <- (seq_along(LETTERS) / length(LETTERS)) - 1e-6
+      for (k in seq_along(n_let)) {
+        detectados <- which(tramero$letra1 == LETTERS[k])
+        tramero$EIN[detectados] <- tramero$EIN[detectados] + n_let[k]
+        detectados <- which(tramero$letra2 == LETTERS[k])
+        tramero$ESN[detectados] <- tramero$ESN[detectados] + n_let[k]
+      }
+      trameros[[paste0("p", i, j)]] <- tramero[, `:=`(
         year    = years[j],
         seccion = paste0(CPRO, CMUM, DIST, SECC),
-        via     = paste0(CPRO, CMUM, CVIA, as.numeric(EIN) %% 2)
-      )]
+        via     = paste0(CPRO, CMUM, CVIA, TINUM)
+      )][, c("TINUM", "letra1", "letra2") := NULL]
     }
   }
   if (y_2001) {

--- a/R/geocodificar.R
+++ b/R/geocodificar.R
@@ -412,7 +412,7 @@ geocodificar_cartociudad <- function(direc, poligono = NULL) {
   devuelve <- data.frame(georef = "NO", stringsAsFactors = FALSE)
 
   # Llamamos a caRtociudad version previa (OLD)
-  fcarto.old <- suppressWarnings(caRtociudad::cartociudad_geocode(direc, version = "prev"))
+  fcarto.old <- suppressWarnings(cartociudad_geocode(direc, version = "prev"))
   if (fcarto.old$state %in% 1:2) {
     devuelve <- fcarto.old[, columnas_elegidas]
     devuelve$georef <- "caRto.OLD"
@@ -433,7 +433,7 @@ geocodificar_cartociudad <- function(direc, poligono = NULL) {
 
   # Llamamos a caRtociudad version nueva (NEW)
   if (substr(devuelve$georef, 1, 2) == "NO" | (devuelve$georef == "caRto.OLD" & fcarto.old$state == "2")) {
-    fcarto.new <- suppressWarnings(caRtociudad::cartociudad_geocode(direc,version = "current"))
+    fcarto.new <- suppressWarnings(cartociudad_geocode(direc,version = "current"))
     if (fcarto.new$state %in% 1:4) {
       devuelve <- fcarto.new[, columnas_elegidas]
       devuelve$georef <- "caRto.NEW"

--- a/R/utils.R
+++ b/R/utils.R
@@ -358,25 +358,26 @@ lee_catastro <- function(archivo) {
   stopifnot(is.character(archivo))
 
   estructura_finca <- readr::fwf_positions(
-    start     = c(1, 26, 31, 51, 81, 154, 334, 343, 672),
-    end       = c(2, 28, 44, 52, 83, 158, 342, 352, 677),
+    start     = c(1, 26, 31, 51, 81, 124, 154, 241, 334, 343, 672),
+    end       = c(2, 28, 44, 52, 83, 153, 158, 245, 342, 352, 677),
     col_names = c("tipo_reg", "muni_dgc", "ref_cat", "prov_ine", "muni_ine",
-                  "via_dgc", "lng", "lat", "epsg")
+                  "entidad", "via_dgc", "codpost", "lng", "lat", "epsg")
   )
-  catastro_finca <- readr::read_fwf(
-    file          = archivo,
-    col_positions = estructura_finca,
-    col_types     = readr::cols(.default = "c"),
-    locale        = readr::locale(encoding = "latin1"),
-    progress      = FALSE
-  )
-
-  catastro_finca <- as.data.table(catastro_finca)[tipo_reg == "11"][, tipo_reg := NULL][]
+  catastro_finca <- as.data.table(
+    readr::read_fwf(
+      file          = archivo,
+      col_positions = estructura_finca,
+      col_types     = readr::cols(.default = "c"),
+      locale        = readr::locale(encoding = "latin1"),
+      progress      = FALSE
+    )
+  )[tipo_reg == "11"][, tipo_reg := NULL][]
 
   estructura_vivienda <- readr::fwf_positions(
-    start     = c(1, 31, 201, 206, 231, 428),
-    end       = c(2, 44, 205, 230, 234, 428),
-    col_names = c("tipo_reg", "ref_cat", "tvias", "vias", "npolis", "clave")
+    start     = c(1, 31, 201, 206, 231, 235, 241, 428),
+    end       = c(2, 44, 205, 230, 234, 235, 245, 428),
+    col_names = c("tipo_reg", "ref_cat", "tvias", "vias",
+                  "npolis", "letra", "km", "clave")
   )
   catastro_vivienda <- as.data.table(
     readr::read_fwf(
@@ -404,10 +405,8 @@ lee_catastro <- function(archivo) {
       tvia  = catastro_vivienda$tvia,
       nvia  = catastro_vivienda$nvia,
       npoli = catastro_vivienda$npoli)][]
-  catastro_finca[, c("lng", "lat") := lapply(.SD, function(x)
-    as.numeric(paste0(substr(x, 1, 2), gsub("^(.{2})", ".", x)))
-  ), .SDcols = c("lng", "lat")
-  ]
+  catastro_finca[, lng := as.numeric(paste0(substr(lng, 1, 7), gsub("^(.{7})", ".", lng)))]
+  catastro_finca[, lat := as.numeric(paste0(substr(lat, 1, 8), gsub("^(.{8})", ".", lat)))]
   attributes(catastro_finca)$epsg <- max(unique(catastro_finca$epsg))
   catastro_finca[, c("epsg") := NULL]
 

--- a/inst/old_functions/old_functions.R
+++ b/inst/old_functions/old_functions.R
@@ -157,7 +157,7 @@ aplica_filtros <- function(vias, datos, indice_nogeo, version_cc, nivel,
             ifelse(version_cc == "prev", "previa", "actual"), ")...")
     geo_res    <- data.table(
       suppressWarnings(
-        caRtociudad::cartociudad_geocode(
+        cartociudad_geocode(
           full_address = res[["via"]],
           version      = version_cc,
           ntries       = intentos
@@ -421,7 +421,7 @@ geocodificar <- function(direcciones, idn = NULL, codigos = NULL, cartografia = 
   message("Buscando en CartoCiudad (versi\u00f3n previa)...")
   geo_old      <- data.table(
     suppressWarnings(
-      caRtociudad::cartociudad_geocode(
+      cartociudad_geocode(
         full_address = datos[["direcciones"]],
         version      = "prev",
         ntries       = intentos
@@ -517,7 +517,7 @@ geocodificar <- function(direcciones, idn = NULL, codigos = NULL, cartografia = 
     message("\nBuscando en CartoCiudad (versi\u00f3n actual)...")
     geo_new     <- data.table(
       suppressWarnings(
-        caRtociudad::cartociudad_geocode(
+        cartociudad_geocode(
           full_address = datos[indice_nogeo_via][["direcciones"]],
           ntries       = intentos
         )

--- a/man/descarga_trameros.Rd
+++ b/man/descarga_trameros.Rd
@@ -34,10 +34,16 @@ Un objeto de clase \code{tramero_ine} con 11 columnas:
   \item{CPRO}{Código de la provincia.} \item{CMUM}{Código del municipio.}
   \item{DIST}{Código del distrito.} \item{SECC}{Código de la sección censal
   reducido.} \item{CVIA}{Código de la vía reducido.} \item{EIN}{Primer portal
-  del tramo de vía.} \item{ESN}{Último portal del tramo de vía.}
+  del tramo de vía (incorpora decimales en caso de tener letra).}
+  \item{ESN}{Último portal del tramo de vía (incorpora decimales en caso de
+  tener letra).} \item{cod_upob}{Código de la entidad poblacional}
+  \item{ent_colectiva}{Nombre de la entidad colectiva.}
+  \item{ent_singular}{Nombre de la entidad singular.}
+  \item{diseminado}{Nombre del núcleo diseminado.}
   \item{NVIAC}{Nombre de la vía.} \item{seccion}{Código de la sección censal
   completo.} \item{year}{Año del tramero.} \item{via}{Código de la vía
-  completo.}
+  completo (el último dígito hace referencia a si el tramo de vía es sin
+  numeración, impar o par (0, 1, o 2, respectivamente).}
 
   Cada fila representa un tramo de vía, puediendo repetirse la misma vía en
   varias ocasiones en función de si su recorrido recae en varias secciones

--- a/vignettes/medear-geocodificacion.Rmd
+++ b/vignettes/medear-geocodificacion.Rmd
@@ -24,7 +24,7 @@ Así pues, en líneas generales la combinación de servicios funciona de la siguien
 
 # Instalación y carga de paquetes de `R`
 
-El primer paso es asegurar que se tiene instalado `R`. El protocolo se ha probado con varias versiones de este software, y aunque es posible ejecutarlo con versiones a partir de la 3.1.0, es recomendable utilizar la última, que es la [3.4.3](https://cran.r-project.org/).
+El primer paso es asegurar que se tiene instalado `R`. El protocolo se ha probado con varias versiones de este software, y aunque es posible ejecutarlo con versiones a partir de la 3.1.0, es recomendable utilizar la última, que es la [3.5.1](https://cran.r-project.org/).
 
 Existen varios paquetes de `R` que permiten establecer una conexión con los servicios de geocodificación. Para facilitar este proceso, se ha creado el paquete [`medear`](https://github.com/fisabio/medear), el cual aglutina las funcionalidades de otros paquetes adaptándolas a nuestras necesidades. Para instalar este paquete y sus dependencias basta con ejecutar el siguiente código en la consola de `R`:
 
@@ -37,12 +37,10 @@ devtools::install_github("fisabio/medear", build_vignettes = TRUE)
 library(medear) # Carga del paquete medear
 ```
 
-Al instalar el paquete `medear` también se instalan todas sus dependencias, que incluyen a los paquetes `ggmap` y `caRtociudad`. Cuando hablamos de `caRtociudad` nos referimos a una [versión propia](https://github.com/carlosvergara/caRtociudad) de este paquete que hemos adaptado de la [versión principal](https://github.com/cjgb/caRtociudad) para este proyecto. Esta versión propia permite, a diferencia de la original, llamar a ambas versiones (antigua y nueva) del servicio de geocodificado de `CartoCiudad`. Las versiones de los paquetes implicados en este protocolo son:
+Al instalar el paquete `medear` también se instalan todas sus dependencias, incluyendo una función propia para llamar al servicio de `CartoCiudad` (adaptada del paquete  [`caRtociudad`](https://github.com/cjgb/caRtociudad) para este proyecto). Esta versión propia permite, a diferencia de la original, llamar a ambas versiones (antigua y nueva) del servicio de geocodificado de `CartoCiudad`. Las versiones de los paquetes implicados en este protocolo son:
 
-* `devtools`: Versión `r packageVersion("devtools")`.
-* `medear`: Versión `r packageVersion("medear")`.
-* `ggmap`: Versión `r packageVersion("ggmap")`.
-* `caRtociudad`: Versión `r packageVersion("caRtociudad")`.
+* `devtools`: versión `>= 1.13.6`.
+* `medear`: versión `>= 0.4.3`.
 
 Si así se desea, es posible consultar este protocolo desde la ayuda del paquete (útil si estás utilizando una interfaz tipo [RStudio](https://www.rstudio.com/)), pues está incorporado dentro del mismo como una viñeta, siendo accesible con la sentencia `vignette("medear-geocodificacion")`.
 
@@ -144,7 +142,7 @@ datosmort$type          <- ""
 
 # Geocodificación de direcciones con `CartoCiudad`
 
-Una vez disponemos de la base de datos de mortalidad en el formato adecuado, pasamos a intentar geocodificar todas las direcciones utilizando el paquete `caRtociudad`. Para ello haremos un uso intensivo de la función `geocodificar_cartociudad` de `medear`, la cual intenta geocodificar cada dirección atendiendo a las dos versiones de `caRtociudad` disponibles a día de hoy. Para más información del funcionamiento interno de dicha función se puede recurrir a la ayuda específica de la misma (`?geocodificar_cartociudad`). Además, en caso de que una dirección no pueda ser geocodificada se prueba si distintas variantes de la dirección pudieran dar algún resultado positivo. Las variantes contempladas son 5, aunque en este protocolo solo vamos a aplicar las dos siguientes:
+Una vez disponemos de la base de datos de mortalidad en el formato adecuado, pasamos a intentar geocodificar todas las direcciones utilizando el servicio de `CartoCiudad`. Para ello haremos un uso intensivo de la función `geocodificar_cartociudad` de `medear`, la cual intenta geocodificar cada dirección atendiendo a las dos versiones de `CartoCiudad` disponibles a día de hoy. Para más información del funcionamiento interno de dicha función se puede recurrir a la ayuda específica de la misma (`?geocodificar_cartociudad`). Además, en caso de que una dirección no pueda ser geocodificada se prueba si distintas variantes de la dirección pudieran dar algún resultado positivo. Las variantes contempladas son 5, aunque en este protocolo solo vamos a aplicar las dos siguientes:
 
 1. eliminar duplicidad de tipos de vía (ejemplo: calle camino ...-> camino ...).
 2. eliminar descripciones de vía (ejemplo: "Avenida rosa (Edificio azul)" -> "Avenida rosa").
@@ -199,7 +197,7 @@ for (i in 1:totno.geo) {
     
     direc <- datosmort$BOD.direccion[cont]
     
-    # Georreferenciación con caRtociudad con comprobación de que la 
+    # Georreferenciación con CartoCiudad con comprobación de que la 
     # geocodificación que hemos obtenido recae geográficamente dentro del 
     # límite geográfico correspondiente a la ciudad.
     aux <- geocodificar_cartociudad(
@@ -207,7 +205,7 @@ for (i in 1:totno.geo) {
       poligono = carto.munis[carto.munis$CUMUN == datosmort$CODMUNIRES[cont], ]
     )
     
-    # En caso de que quisiéramos geocodificar con caRtociudad sin más, 
+    # En caso de que quisiéramos geocodificar con CartoCiudad sin más, 
     # sin comprobar que el punto que obtenemos está incluido en una región 
     # geográfica concreta, ejecutaríamos simplemente: 
     # aux <- geocodificar_cartociudad(direc = direc)
@@ -252,7 +250,7 @@ for (i in 1:totno.geo) {
 }
 
 # Una vez finalizado el proceso guardamos una copia de los datos geocodificados por 
-# caRtociudad antes de pasar a google
+# CartoCiudad antes de pasar a google
 
 ###### Creamos el directorio (en caso de no existir) donde se guardarán los datos
 if (!dir.exists("datos/mortalidad"))
@@ -262,7 +260,7 @@ save(datosmort, file = "datos/mortalidad/mortalidad_geocodificada.RData")
 
 # Geocodificación de las direcciones restantes con `Google`
 
-En el apartado anterior se debería haber geocodificado una gran proporción de las direcciones (en nuestras pruebas, la cifra varía entre un 85 y 95 %), y ahora se hará uso del servicio de geocodificación de `Google` para tratar de geocodificar todos los registros que no hayan podido ser geocodificados con `caRtociudad`.
+En el apartado anterior se debería haber geocodificado una gran proporción de las direcciones (en nuestras pruebas, la cifra varía entre un 85 y 95 %), y ahora se hará uso del servicio de geocodificación de `Google` para tratar de geocodificar todos los registros que no hayan podido ser geocodificados con `CartoCiudad`.
 
 Debido al límite de consultas diarias que impone la versión gratuita del servicio de `Google` (teóricamente de 2500, aunque hemos observado que esta cifra puede variar mucho), es muy probable que tengamos que enviar algunas direcciones varias veces a este servicio, en días distintos, para poder completar el proceso. Para entender mejor el proceso que sigue a continuación, se debe tener en cuenta la respuesta que devuelve el servicio de `Google` al tratar de geocodificar un registro:
 


### PR DESCRIPTION
Eliminar dependencias a caRtociudad y ggmap (se incorporan las funciones pertinentes dentro del paquete). Se actualiza el protocolo de geocodificación.

Se añade información extra en la lectura de los callejeros y de la información catastral.